### PR TITLE
[feat] 예약 직거래 시 상태 변경

### DIFF
--- a/src/app/profile/posts/page.tsx
+++ b/src/app/profile/posts/page.tsx
@@ -404,6 +404,8 @@ function PostCard({ post }: { post: Post }) {
                       status === "INSPECTING_RETURN";
                     const canRequestRefund = status === "RETURN_COMPLETED";
                     const canMarkLostOrUnreturned = status === "RENTING";
+                    const canRequestClaimForLost =
+                      status === "LOST_OR_UNRETURNED";
 
                     return (
                       <Card key={reservation.id} className="bg-gray-50">
@@ -781,6 +783,37 @@ function PostCard({ post }: { post: Post }) {
                                   className="text-red-600 border-red-600 hover:bg-red-50"
                                 >
                                   미반납/분실 처리
+                                </Button>
+                              )}
+
+                              {/* 호스트 - 미반납/분실 상태일 때 청구 요청 (LOST_OR_UNRETURNED → CLAIMING) */}
+                              {canRequestClaimForLost && (
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={async () => {
+                                    try {
+                                      await updateStatusMutation.mutateAsync({
+                                        reservationId: reservation.id,
+                                        data: {
+                                          status: ReservationStatus.CLAIMING,
+                                        },
+                                      });
+                                      showToast(
+                                        "청구 진행 상태로 변경되었습니다.",
+                                        "success",
+                                      );
+                                    } catch (error) {
+                                      console.error(
+                                        "Failed to request claim:",
+                                        error,
+                                      );
+                                    }
+                                  }}
+                                  disabled={updateStatusMutation.isPending}
+                                  className="text-red-600 border-red-600 hover:bg-red-50"
+                                >
+                                  청구 요청
                                 </Button>
                               )}
                             </div>

--- a/src/app/profile/reservations/page.tsx
+++ b/src/app/profile/reservations/page.tsx
@@ -317,6 +317,7 @@ export default function MyReservationsPage() {
               const canCompleteInspection =
                 status === "INSPECTING_RENTAL";
               const canStartReturn = status === "RENTING";
+              const canMarkLostOrUnreturned = status === "RENTING";
               const canSendReturnShipping =
                 status === "PENDING_RETURN" &&
                 reservation.returnMethod != null &&
@@ -478,27 +479,57 @@ export default function MyReservationsPage() {
 
                           {/* 게스트 - 대여 중일 때 반납하기 (RENTING → PENDING_RETURN) */}
                           {canStartReturn && (
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={async () => {
-                                try {
-                                  await updateStatusMutation.mutateAsync({
-                                    reservationId: reservation.id,
-                                    data: {
-                                      status: ReservationStatus.PENDING_RETURN,
-                                    },
-                                  });
-                                  showToast("반납 대기 상태로 변경되었습니다.", "success");
-                                } catch (error) {
-                                  console.error("Failed to start return:", error);
-                                }
-                              }}
-                              disabled={updateStatusMutation.isPending}
-                              className="border-purple-600 text-purple-600 hover:bg-purple-50"
-                            >
-                              반납하기
-                            </Button>
+                            <>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={async () => {
+                                  try {
+                                    await updateStatusMutation.mutateAsync({
+                                      reservationId: reservation.id,
+                                      data: {
+                                        status: ReservationStatus.PENDING_RETURN,
+                                      },
+                                    });
+                                    showToast("반납 대기 상태로 변경되었습니다.", "success");
+                                  } catch (error) {
+                                    console.error("Failed to start return:", error);
+                                  }
+                                }}
+                                disabled={updateStatusMutation.isPending}
+                                className="border-purple-600 text-purple-600 hover:bg-purple-50"
+                              >
+                                반납하기
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={async () => {
+                                  try {
+                                    await updateStatusMutation.mutateAsync({
+                                      reservationId: reservation.id,
+                                      data: {
+                                        status:
+                                          ReservationStatus.LOST_OR_UNRETURNED,
+                                      },
+                                    });
+                                    showToast(
+                                      "미반납/분실 상태로 변경되었습니다.",
+                                      "success",
+                                    );
+                                  } catch (error) {
+                                    console.error(
+                                      "Failed to mark lost or unreturned:",
+                                      error,
+                                    );
+                                  }
+                                }}
+                                disabled={updateStatusMutation.isPending}
+                                className="border-red-600 text-red-600 hover:bg-red-50"
+                              >
+                                미반납/분실 처리
+                              </Button>
+                            </>
                           )}
 
 


### PR DESCRIPTION
## 🔖 관련 이슈

> (예시) Closes #103

- Closes #24 

## 🛠️ 작업 내용

> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요

- 예약 직거래 시 배송 완료 단계로 넘어가도록 로직 추가
- 미반납/분실을 게스트/호스트 측 양쪽에서 동작하도록 변경
- 미반납/분실 상태에서 호스트가 청구 요청하도록 추가

## 🎨 스크린샷 / 화면 예시 (선택)

### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)

> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요

-
