### PR TITLE
[fix] 채팅 웹소켓 연결 문제 해결

### DIFF
--- a/src/hooks/useStomp.ts
+++ b/src/hooks/useStomp.ts
@@ -41,7 +41,7 @@ export function useStomp() {
 
     const client = new Client({
       brokerURL:
-        process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:8080/ws-chat",
+        process.env.NEXT_PUBLIC_WS_BASE_URL || "ws://localhost:8080/ws-chat",
       reconnectDelay: 3000,
       heartbeatIncoming: 4000,
       heartbeatOutgoing: 4000,


### PR DESCRIPTION
## 🔖 관련 이슈

> (예시) Closes #103

- Closes #32 

## 🛠️ 작업 내용

> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요

- 배포환경에서 채팅 웹소켓이 로컬로 요청되는 문제 해결

## 🎨 스크린샷 / 화면 예시 (선택)

### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)

> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요

- 문제 원인 1 : env 주소 잘못 읽어와서 default로 로컬에 요청됨
- 문제 원인 2 : env 웹소켓 연결 주소 잘못됨 (환경변수 페이지에 수정해서 적어뒀습니다.)
