### PR TITLE
[FEAT] 내 정보 수정 기능 추가

### DIFF
--- a/src/api/endpoints/user.ts
+++ b/src/api/endpoints/user.ts
@@ -42,7 +42,7 @@ export async function getMe(): Promise<MemberResponse> {
 export async function updateUser(
   data: UpdateMemberDto | FormData,
 ): Promise<MemberResponse> {
-  return apiClient.put<MemberResponse>("/api/v1/members/me", data, {
+  return apiClient.patch<MemberResponse>("/api/v1/members/me", data, {
     isFormData: data instanceof FormData,
   });
 }

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -58,12 +58,11 @@ export interface CreateMemberDto {
  * 사용자 수정 DTO
  */
 export interface UpdateMemberDto {
-  name?: string;
-  phoneNumber?: string;
-  address1?: string;
-  address2?: string;
-  nickname?: string;
-  profileImgUrl?: string;
+  address1: string;
+  address2: string;
+  nickname: string;
+  phoneNumber: string;
+  removeProfileImage: boolean;
 }
 
 /**


### PR DESCRIPTION
## 🔖 관련 이슈

> (예시) Closes #103
- Closes #46 

## 🛠️ 작업 내용

> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 내 정보 화면에서 닉네임, 전화번호, 주소, 프로필 이미지 수정
- 주소 수정 방식을 회원가입에서 사용한 Kakao API 활용 방식으로 수정
- 프로필 이미지의 경우 이미지 파일 업로드와, 이미지 삭제 boolean(removeProfileImage)를 바탕으로 등록, 수정, 삭제 기능 구현

## 🎨 스크린샷 / 화면 예시 (선택)

### 🕒 수정 전

-

### ✨ 수정 후

<img width="835" height="723" alt="image" src="https://github.com/user-attachments/assets/72542a15-faf0-4bc4-8798-091a948ac8fb" />

## 👀 리뷰 요청 사항 (선택)

> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 
