### PR TITLE
[FIX] 내 게시글의 예약 목록 총 금액 출력 수정

### DIFF
--- a/src/app/profile/posts/page.tsx
+++ b/src/app/profile/posts/page.tsx
@@ -71,6 +71,10 @@ import {
  * 마이페이지 - 내 게시글
  */
 
+/**
+ * 마이페이지 - 내 게시글
+ */
+
 const statusLabels: Record<string, string> = {
   PENDING_APPROVAL: "승인 대기",
   PENDING_PAYMENT: "결제 대기",
@@ -389,7 +393,7 @@ function PostCard({ post }: { post: Post }) {
                             (reservationEndDate.getTime() -
                               reservationStartDate.getTime()) /
                               (1000 * 60 * 60 * 24),
-                          ) + 1
+                          )
                         : 0;
 
                     // 옵션 목록


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #146

## 🛠️ 작업 내용

> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 내 게시글의 예약 목록 총 금액을 프론트에서 총 금액을 계산하지 않고 서버에서 받아온 응답 값으로 수정

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전
-

### ✨ 수정 후
-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
-
